### PR TITLE
Drill-through navigation

### DIFF
--- a/src/Depends/Depends.csproj
+++ b/src/Depends/Depends.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.8" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0" />
-    <PackageReference Include="Terminal.Gui" Version="0.81.0" />
+    <PackageReference Include="Terminal.Gui" Version="1.3.1" />
     <PackageReference Include="MinVer" Version="2.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Depends/Program.cs
+++ b/src/Depends/Program.cs
@@ -234,6 +234,8 @@ namespace Depends
                 right.Add(runtimeDepends, packageDepends, reverseDepends);
                 Add(left, right, helpText);
 
+                _runtimeDependsView.OpenSelectedItem += RuntimeDependsView_OpenSelectedItem;
+
                 _dependenciesView.SelectedItemChanged += (args) => UpdateLists();
                 _dependenciesView.SetSource(_visibleDependencies);
             }
@@ -252,6 +254,13 @@ namespace Depends
                 }
 
                 return base.ProcessKey(keyEvent);
+            }
+
+            private void RuntimeDependsView_OpenSelectedItem(ListViewItemEventArgs args)
+            {
+                var index = _visibleDependencies.FindIndex(x => x.Equals(args.Value));
+                _dependenciesView.SelectedItem = index;
+                _dependenciesView.SetFocus();
             }
 
             private void UpdateLists()

--- a/src/Depends/Program.cs
+++ b/src/Depends/Program.cs
@@ -155,7 +155,7 @@ namespace Depends
             {
                 Y = Pos.Bottom(runtimeDepends),
                 Width = Dim.Fill(),
-                Height = Dim.Percent(50f)
+                Height = Dim.Percent(33f)
             };
             var reverseDepends = new FrameView("Reverse depends")
             {

--- a/src/Depends/Program.cs
+++ b/src/Depends/Program.cs
@@ -127,6 +127,7 @@ namespace Depends
             }
 
             Application.Init();
+            Application.QuitKey = Key.Esc;
 
             var top = new CustomWindow();
 
@@ -244,11 +245,6 @@ namespace Depends
 
             public override bool ProcessKey(KeyEvent keyEvent)
             {
-                if (keyEvent.Key == Key.Esc)
-                {
-                    Application.RequestStop();
-                    return true;
-                }
                 if (keyEvent.Key == (Key.D | Key.CtrlMask))
                 {
                     _assembliesVisible = !_assembliesVisible;

--- a/src/Depends/Program.cs
+++ b/src/Depends/Program.cs
@@ -272,7 +272,7 @@ namespace Depends
 
                     _dependenciesView.SetSource(_visibleDependencies);
                     _lastSelectedDependencyIndex = -1;
-                    _dependenciesView.SelectedItem = 0;
+                    _dependenciesView.SetFocus();
                     return true;
                 }
 

--- a/src/Depends/Program.cs
+++ b/src/Depends/Program.cs
@@ -277,23 +277,24 @@ namespace Depends
 
             private void RuntimeDependsView_OpenSelectedItem(ListViewItemEventArgs args)
             {
-                var index = _visibleDependencies.FindIndex(x => x.Equals(args.Value));
-                _dependenciesView.SelectedItem = index;
-                _dependenciesView.SetFocus();
+                SetSelectedDependency((Node)args.Value);
             }
 
             private void PackageDependsView_OpenSelectedItem(ListViewItemEventArgs args)
             {
-                var selectedNode = ((DependsListItemModel)args.Value).Node;
-                var index = _visibleDependencies.FindIndex(x => x.Equals(selectedNode));
-                _dependenciesView.SelectedItem = index;
-                _dependenciesView.SetFocus();
+                var node = ((DependsListItemModel)args.Value).Node;
+                SetSelectedDependency(node);
             }
 
             private void ReverseDependsView_OpenSelectedItem(ListViewItemEventArgs args)
             {
-                var selectedNode = ((DependsListItemModel)args.Value).Node;
-                var index = _visibleDependencies.FindIndex(x => x.Equals(selectedNode));
+                var node = ((DependsListItemModel)args.Value).Node;
+                SetSelectedDependency(node);
+            }
+
+            private void SetSelectedDependency(Node node)
+            {
+                var index = _visibleDependencies.FindIndex(x => x.Equals(node));
                 _dependenciesView.SelectedItem = index;
                 _dependenciesView.SetFocus();
             }

--- a/src/Depends/Program.cs
+++ b/src/Depends/Program.cs
@@ -206,14 +206,11 @@ namespace Depends
             top.VisibleDependencies = orderedDependencyList;
             top.DependenciesView = dependenciesView;
 
-            dependenciesView.SelectedItem = 0;
-            UpdateLists();
-
-            dependenciesView.SelectedItemChanged += (_) => UpdateLists();
+            dependenciesView.SelectedItemChanged += UpdateLists;
 
             Application.Run();
 
-            void UpdateLists()
+            void UpdateLists(ListViewItemEventArgs e)
             {
                 var selectedNode = top.VisibleDependencies[dependenciesView.SelectedItem];
 

--- a/src/Depends/Program.cs
+++ b/src/Depends/Program.cs
@@ -277,7 +277,11 @@ namespace Depends
 
             private void RuntimeDependsView_OpenSelectedItem(ListViewItemEventArgs args)
             {
-                SetSelectedDependency((Node)args.Value);
+                if(_assembliesVisible)
+                {
+                    SetSelectedDependency((Node)args.Value);
+                }
+                // else: would be nice to provide a feedback so that the user understands that navigation is not possible.
             }
 
             private void PackageDependsView_OpenSelectedItem(ListViewItemEventArgs args)

--- a/src/Depends/Program.cs
+++ b/src/Depends/Program.cs
@@ -235,7 +235,7 @@ namespace Depends
                     Focus = Application.Driver.MakeAttribute(Color.Black, Color.White),
                     Normal = Application.Driver.MakeAttribute(Color.White, Color.Black),
                     HotFocus = Application.Driver.MakeAttribute(Color.Black, Color.White),
-                    HotNormal = Application.Driver.MakeAttribute(Color.Black, Color.White)
+                    HotNormal = Application.Driver.MakeAttribute(Color.White, Color.Black)
                 };
             }
 

--- a/src/Depends/Program.cs
+++ b/src/Depends/Program.cs
@@ -154,8 +154,8 @@ namespace Depends
             {
                 _graph = graph ?? throw new ArgumentNullException(nameof(graph));
                 _dependencies = _graph.Nodes.OrderBy(x => x.Id).ToImmutableList();
-                _assembliesVisible = true;
                 _visibleDependencies = _dependencies;
+                _assembliesVisible = true;
 
                 ColorScheme = new ColorScheme
                 {
@@ -235,7 +235,7 @@ namespace Depends
                 Add(left, right, helpText);
 
                 _dependenciesView.SelectedItemChanged += (args) => UpdateLists();
-                _dependenciesView.SetSource(_dependencies);
+                _dependenciesView.SetSource(_visibleDependencies);
             }
 
             public override bool ProcessKey(KeyEvent keyEvent)

--- a/src/Depends/Program.cs
+++ b/src/Depends/Program.cs
@@ -111,6 +111,16 @@ namespace Depends
                 .SetMinimumLevel(Verbosity)
                 .AddConsole());
 
+            var graph = GetDependencyGraph(loggerFactory);
+
+            Application.Init();
+            Application.QuitKey = Key.Esc;
+            Application.Top.Add(new AppWindow(graph));
+            Application.Run();
+        }
+
+        private DependencyGraph GetDependencyGraph(ILoggerFactory loggerFactory)
+        {
             var analyzer = new DependencyAnalyzer(loggerFactory);
             DependencyGraph graph;
             if (!string.IsNullOrEmpty(Package))
@@ -125,11 +135,7 @@ namespace Depends
             {
                 graph = analyzer.Analyze(Project, Framework);
             }
-
-            Application.Init();
-            Application.QuitKey = Key.Esc;
-            Application.Top.Add(new AppWindow(graph));
-            Application.Run();
+            return graph;
         }
 
         private class AppWindow : Window

--- a/src/Depends/Program.cs
+++ b/src/Depends/Program.cs
@@ -168,25 +168,33 @@ namespace Depends
             var dependenciesView = new ListView(orderedDependencyList)
             {
                 CanFocus = true,
-                AllowsMarking = false
+                AllowsMarking = false,
+                Width = Dim.Fill(),
+                Height = Dim.Fill()
             };
             left.Add(dependenciesView);
             var runtimeDependsView = new ListView(Array.Empty<Node>())
             {
                 CanFocus = true,
-                AllowsMarking = false
+                AllowsMarking = false,
+                Width = Dim.Fill(),
+                Height = Dim.Fill()
             };
             runtimeDepends.Add(runtimeDependsView);
             var packageDependsView = new ListView(Array.Empty<Node>())
             {
                 CanFocus = true,
-                AllowsMarking = false
+                AllowsMarking = false,
+                Width = Dim.Fill(),
+                Height = Dim.Fill()
             };
             packageDepends.Add(packageDependsView);
             var reverseDependsView = new ListView(Array.Empty<Node>())
             {
                 CanFocus = true,
-                AllowsMarking = false
+                AllowsMarking = false,
+                Width = Dim.Fill(),
+                Height = Dim.Fill()
             };
             reverseDepends.Add(reverseDependsView);
 
@@ -201,7 +209,7 @@ namespace Depends
             dependenciesView.SelectedItem = 0;
             UpdateLists();
 
-            dependenciesView.SelectedChanged += UpdateLists;
+            dependenciesView.SelectedItemChanged += (_) => UpdateLists();
 
             Application.Run();
 
@@ -244,7 +252,7 @@ namespace Depends
                     Application.RequestStop();
                     return true;
                 }
-                if (keyEvent.Key == Key.ControlD)
+                if (keyEvent.Key == (Key.D | Key.CtrlMask))
                 {
                     _assembliesVisible = !_assembliesVisible;
 

--- a/src/Depends/Program.cs
+++ b/src/Depends/Program.cs
@@ -269,6 +269,7 @@ namespace Depends
                         _dependencies.Where(d => !(d is AssemblyReferenceNode)).ToImmutableList();
 
                     _dependenciesView.SetSource(_visibleDependencies);
+                    _dependenciesView.SelectedItem = 0;
                     return true;
                 }
 


### PR DESCRIPTION
This PR adds simple drill-through navigation for the runtime, package, and reverse dependencies lists.

Inspired by https://github.com/bjorkstromm/depends/issues/20, but history (go back) is not implemented.
