### PR TITLE
Fix for KeyNotFoundException when a package dependency does not appear in the list of libraries taken from the lock file

### DIFF
--- a/src/Depends.Core/DependencyAnalyzer.cs
+++ b/src/Depends.Core/DependencyAnalyzer.cs
@@ -297,6 +297,15 @@ namespace Depends.Core
                     //}
                 }
 
+                // Not all dependencies are necessarily included in the list of libraries
+                // for the current target framework and runtime identifier. Add these to libraryNodes
+                // so we can still record these dependencies.
+                foreach (var dependency in libraries.SelectMany(library => library.Dependencies))
+                {
+                    Console.WriteLine(dependency.Id);
+                    libraryNodes.TryAdd(dependency.Id, new PackageReferenceNode(dependency.Id, ""));
+                }
+
                 foreach (var library in libraries)
                 {
                     var libraryNode = library.ToNode();

--- a/src/Depends.Core/DependencyAnalyzer.cs
+++ b/src/Depends.Core/DependencyAnalyzer.cs
@@ -262,7 +262,15 @@ namespace Depends.Core
                 {
                     var libraryNode = library.ToNode();
                     builder.WithNode(libraryNode);
-                    libraryNodes.Add(libraryNode.PackageId, libraryNode);
+                    libraryNodes[libraryNode.PackageId] = libraryNode;
+
+                    // Not all dependencies are necessarily included in the list of libraries
+                    // for the current target framework and runtime identifier. Add these to libraryNodes
+                    // so we can still record these dependencies.
+                    foreach (var dependency in library.Dependencies)
+                    {
+                        libraryNodes.TryAdd(dependency.Id, new PackageReferenceNode(dependency.Id, ""));
+                    }
 
                     if (library.FrameworkAssemblies.Count > 0)
                     {
@@ -297,13 +305,6 @@ namespace Depends.Core
                     //}
                 }
 
-                // Not all dependencies are necessarily included in the list of libraries
-                // for the current target framework and runtime identifier. Add these to libraryNodes
-                // so we can still record these dependencies.
-                foreach (var dependency in libraries.SelectMany(library => library.Dependencies))
-                {
-                    libraryNodes.TryAdd(dependency.Id, new PackageReferenceNode(dependency.Id, ""));
-                }
 
                 foreach (var library in libraries)
                 {

--- a/src/Depends.Core/DependencyAnalyzer.cs
+++ b/src/Depends.Core/DependencyAnalyzer.cs
@@ -262,6 +262,8 @@ namespace Depends.Core
                 {
                     var libraryNode = library.ToNode();
                     builder.WithNode(libraryNode);
+
+                    // Overwrite any previous additions that may have been added by the loop below.
                     libraryNodes[libraryNode.PackageId] = libraryNode;
 
                     // Not all dependencies are necessarily included in the list of libraries
@@ -269,7 +271,10 @@ namespace Depends.Core
                     // so we can still record these dependencies.
                     foreach (var dependency in library.Dependencies)
                     {
-                        libraryNodes.TryAdd(dependency.Id, new PackageReferenceNode(dependency.Id, ""));
+                        // Add min version in version range if this dependency doesn't exist
+                        libraryNodes.TryAdd(
+                            dependency.Id,
+                            new PackageReferenceNode(dependency.Id, dependency.VersionRange.MinVersion.ToString()));
                     }
 
                     if (library.FrameworkAssemblies.Count > 0)

--- a/src/Depends.Core/DependencyAnalyzer.cs
+++ b/src/Depends.Core/DependencyAnalyzer.cs
@@ -302,7 +302,6 @@ namespace Depends.Core
                 // so we can still record these dependencies.
                 foreach (var dependency in libraries.SelectMany(library => library.Dependencies))
                 {
-                    Console.WriteLine(dependency.Id);
                     libraryNodes.TryAdd(dependency.Id, new PackageReferenceNode(dependency.Id, ""));
                 }
 


### PR DESCRIPTION
Hi, I recently discovered this tool and it seems really helpful, especially for the kind of projects I have to deal with at work which have very big dependency trees that are constantly being updated.

Unfortunately, when trying this tool on some of those projects, I've been getting a KeyNotFoundException on line 307. It seems that -for some reason- some of the dependencies of my packages are not listed in lock file, except as dependencies. I haven't been able to find an explanation for why that is, I only really have surgace-level knowledge of project.assets.json contents. I'm getting this with various packages (eg: Nerdbank.GitVersioning, NETStandard.Library) but have been unable to put together a minimal repro.

Regardless, my project files build and run just fine at the moment, so I assume this must be valid and should be a situation this tool ought to handle.