### PR TITLE
Add Alphabetical Sorting of Packages

### DIFF
--- a/src/Depends/Program.cs
+++ b/src/Depends/Program.cs
@@ -323,11 +323,11 @@ namespace Depends
                 var selectedNode = _visibleDependencies[_dependenciesView.SelectedItem];
 
                 _runtimeDependsView.SetSource(_graph.Edges.Where(x => x.Start.Equals(selectedNode) && x.End is AssemblyReferenceNode)
-                    .Select(x => x.End).ToImmutableList());
+                    .Select(x => x.End).OrderBy(x => x.Id).ToImmutableList());
                 _packageDependsView.SetSource(_graph.Edges.Where(x => x.Start.Equals(selectedNode) && x.End is PackageReferenceNode)
-                    .Select(x => new DependsListItemModel(x.End, x.Label)).ToImmutableList());
+                    .Select(x => new DependsListItemModel(x.End, x.Label)).OrderBy(x => x.DisplayText).ToImmutableList());
                 _reverseDependsView.SetSource(_graph.Edges.Where(x => x.End.Equals(selectedNode))
-                    .Select(x => new DependsListItemModel(x.Start, x.Label)).ToImmutableList());
+                    .Select(x => new DependsListItemModel(x.Start, x.Label)).OrderBy(x => x.DisplayText).ToImmutableList());
             }
         }
     }


### PR DESCRIPTION
The is a small quality of life improvement. Currently the tool does not have sorted output in the dependencies/reverse dependencies view which makes it hard to search for a particular package or to diff results from different projects